### PR TITLE
Update virtual keyboard toggles and AI section visibility

### DIFF
--- a/lib/ide_screen.dart
+++ b/lib/ide_screen.dart
@@ -111,6 +111,10 @@ class _IDEScreenState extends State<IDEScreen> {
   // Input management
   final TextEditingController _promptController = TextEditingController();
   final FocusNode _promptFocus = FocusNode();
+  final FocusNode _fullscreenToggleFocusNode = FocusNode(
+    skipTraversal: true,
+    canRequestFocus: false,
+  );
 
   // State management
   bool _isGenerating = false;
@@ -332,6 +336,7 @@ document.addEventListener('DOMContentLoaded', function() {
   void dispose() {
     _promptController.dispose();
     _promptFocus.dispose();
+    _fullscreenToggleFocusNode.dispose();
     super.dispose();
   }
 
@@ -3929,6 +3934,8 @@ $jsContent
               child: FloatingActionButton.small(
                 heroTag: 'fullscreen-toggle',
                 onPressed: _toggleFullscreenMode,
+                focusNode: _fullscreenToggleFocusNode,
+                autofocus: false,
                 tooltip:
                     _isFullscreenMode
                         ? 'Exit Fullscreen'


### PR DESCRIPTION
Summary
- keep per-editor virtual keyboard position when toggling visibility, add explicit toolbar button, and expose toggle in the UI so keyboard state persists across show/hide cycles
- gate the AI text generation input/history behind a visibility toggle (toolbar button + floating action button) and hide history when collapsing
- refresh web interop to only block system keyboards on touch devices, refresh Firebase config, and accept updated Dart/flutter transitive deps

Testing
- Not run (not requested)