### PR TITLE
Add Windows Chrome PWA install and open-in-app support

### DIFF
--- a/lib/ide_screen.dart
+++ b/lib/ide_screen.dart
@@ -119,6 +119,8 @@ class _IDEScreenState extends State<IDEScreen> {
   // State management
   bool _isGenerating = false;
   String? _errorMessage;
+  bool _showPwaInstallAction = false;
+  bool _isPwaInstalled = false;
 
   // History management
   bool _showHistoryPanel = false;
@@ -131,6 +133,7 @@ class _IDEScreenState extends State<IDEScreen> {
   @override
   void initState() {
     super.initState();
+    _initializePwaInstallAction();
 
     // Initialize state only for currently active editors (default = 1).
     // Remaining editor slots are lazily completed when user increases count.
@@ -334,10 +337,74 @@ document.addEventListener('DOMContentLoaded', function() {
 
   @override
   void dispose() {
+    interop.clearPwaStatusListener();
     _promptController.dispose();
     _promptFocus.dispose();
     _fullscreenToggleFocusNode.dispose();
     super.dispose();
+  }
+
+  void _initializePwaInstallAction() {
+    try {
+      interop.setPwaStatusListener(_refreshPwaInstallAction);
+      _refreshPwaInstallAction();
+    } catch (e) {
+      print('Failed to initialize PWA install action: $e');
+    }
+  }
+
+  void _refreshPwaInstallAction() {
+    if (!mounted) return;
+
+    try {
+      final isSupported = interop.isPwaInstallSupported();
+      final isStandalone = interop.isRunningAsPwa();
+      final isInstalled = interop.isPwaInstalled();
+      final canInstall = interop.isPwaInstallAvailable();
+      final shouldShow = isSupported && !isStandalone && (canInstall || isInstalled);
+
+      if (_showPwaInstallAction == shouldShow && _isPwaInstalled == isInstalled) {
+        return;
+      }
+
+      setState(() {
+        _showPwaInstallAction = shouldShow;
+        _isPwaInstalled = isInstalled;
+      });
+    } catch (e) {
+      print('Failed to refresh PWA install action: $e');
+    }
+  }
+
+  Future<void> _handlePwaInstallAction() async {
+    if (_isPwaInstalled) {
+      final opened = interop.openPwaApp();
+      _showSnackBar(
+        opened
+            ? 'Attempting to open the installed app...'
+            : 'Open the app from your Start menu or Chrome Apps.',
+      );
+      return;
+    }
+
+    try {
+      final result = await interop.promptPwaInstall();
+      _refreshPwaInstallAction();
+
+      switch (result) {
+        case 'accepted':
+          _showSnackBar('App installed. You can now open it like a desktop app.');
+          break;
+        case 'dismissed':
+          _showSnackBar('Install prompt dismissed.');
+          break;
+        default:
+          _showSnackBar('Install is available only in Chrome on Windows when the app is eligible.');
+      }
+    } catch (e) {
+      _showSnackBar('Unable to show the install prompt right now.');
+      print('Failed to handle PWA install action: $e');
+    }
   }
 
   @override
@@ -2784,6 +2851,18 @@ $jsContent
         ),
         backgroundColor: Colors.grey[900],
         actions: [
+          if (_showPwaInstallAction)
+            TextButton.icon(
+              onPressed: _handlePwaInstallAction,
+              icon: Icon(
+                _isPwaInstalled ? Icons.open_in_new : Icons.download_for_offline,
+                color: Colors.white,
+              ),
+              label: Text(
+                _isPwaInstalled ? 'Open in app' : 'Install app',
+                style: const TextStyle(color: Colors.white),
+              ),
+            ),
           if (!isAuthenticated)
             TextButton(
               onPressed: _openLoginFromToolbar,

--- a/lib/interop.dart
+++ b/lib/interop.dart
@@ -208,3 +208,50 @@ Future<void> triggerLayoutRecalculation() async {
     print('Failed to trigger layout recalculation: $e');
   }
 }
+
+// PWA install/open bindings
+@JS('pwaInstallInterop.isSupported')
+external JSBoolean _isPwaInstallSupported();
+
+bool isPwaInstallSupported() => _isPwaInstallSupported().toDart;
+
+@JS('pwaInstallInterop.isInstallAvailable')
+external JSBoolean _isPwaInstallAvailable();
+
+bool isPwaInstallAvailable() => _isPwaInstallAvailable().toDart;
+
+@JS('pwaInstallInterop.isInstalled')
+external JSBoolean _isPwaInstalled();
+
+bool isPwaInstalled() => _isPwaInstalled().toDart;
+
+@JS('pwaInstallInterop.isStandalone')
+external JSBoolean _isRunningAsPwa();
+
+bool isRunningAsPwa() => _isRunningAsPwa().toDart;
+
+@JS('pwaInstallInterop.promptInstall')
+external JSPromise _promptPwaInstall();
+
+Future<String> promptPwaInstall() {
+  return _promptPwaInstall().toDart.then((value) => (value as JSString).toDart);
+}
+
+@JS('pwaInstallInterop.openApp')
+external JSBoolean _openPwaApp();
+
+bool openPwaApp() => _openPwaApp().toDart;
+
+@JS('pwaInstallInterop.setStatusListener')
+external void _setPwaStatusListener(JSFunction listener);
+
+void setPwaStatusListener(void Function() listener) {
+  _setPwaStatusListener(listener.toJS);
+}
+
+@JS('pwaInstallInterop.clearStatusListener')
+external void _clearPwaStatusListener();
+
+void clearPwaStatusListener() {
+  _clearPwaStatusListener();
+}

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,9 @@
     <meta charset="UTF-8">
     <meta content="IE=Edge" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#1E1E1E">
+    <link rel="manifest" href="manifest.json">
+    <link rel="apple-touch-icon" href="icons/Icon-192.png">
     <title>HTML Web IDE</title>
     <style>
         body {

--- a/web/interop.js
+++ b/web/interop.js
@@ -32,6 +32,134 @@ function loadMonaco() {
 
 console.log('Monaco Interop JavaScript loaded');
 
+// PWA install/open bridge for Windows Chrome.
+window.pwaInstallInterop = (() => {
+  const installedStorageKey = 'flutter_html_web_ide_pwa_installed';
+  let deferredInstallPrompt = null;
+  let statusListener = null;
+  let relatedAppInstalled = false;
+
+  function isWindowsChrome() {
+    const ua = navigator.userAgent || '';
+    const vendor = navigator.vendor || '';
+    const isWindows = /Windows/i.test(ua);
+    const isChrome = /Chrome/i.test(ua) && /Google Inc/i.test(vendor);
+    const isEdge = /Edg/i.test(ua);
+    const isOpera = /OPR|Opera/i.test(ua);
+    return isWindows && isChrome && !isEdge && !isOpera;
+  }
+
+  function isStandaloneMode() {
+    return window.matchMedia('(display-mode: standalone)').matches ||
+      window.matchMedia('(display-mode: window-controls-overlay)').matches ||
+      navigator.standalone === true;
+  }
+
+  function isInstalled() {
+    if (isStandaloneMode()) {
+      return true;
+    }
+
+    try {
+      return relatedAppInstalled || window.localStorage.getItem(installedStorageKey) === 'true';
+    } catch (_) {
+      return relatedAppInstalled;
+    }
+  }
+
+  function isInstallAvailable() {
+    return isWindowsChrome() && deferredInstallPrompt !== null && !isStandaloneMode();
+  }
+
+  function notifyStatusChanged() {
+    if (typeof statusListener === 'function') {
+      statusListener();
+    }
+  }
+
+  async function refreshInstalledStatus() {
+    if (typeof navigator.getInstalledRelatedApps !== 'function' || !isWindowsChrome()) {
+      relatedAppInstalled = false;
+      notifyStatusChanged();
+      return;
+    }
+
+    try {
+      const relatedApps = await navigator.getInstalledRelatedApps();
+      relatedAppInstalled = relatedApps.some((app) => app.platform === 'webapp');
+    } catch (_) {
+      relatedAppInstalled = false;
+    }
+
+    notifyStatusChanged();
+  }
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredInstallPrompt = event;
+    notifyStatusChanged();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredInstallPrompt = null;
+    try {
+      window.localStorage.setItem(installedStorageKey, 'true');
+    } catch (_) {}
+    refreshInstalledStatus();
+  });
+
+  const displayModeQuery = window.matchMedia('(display-mode: standalone)');
+  if (typeof displayModeQuery.addEventListener === 'function') {
+    displayModeQuery.addEventListener('change', notifyStatusChanged);
+  }
+
+  window.addEventListener('focus', refreshInstalledStatus);
+  refreshInstalledStatus();
+
+  return {
+    isSupported: () => isWindowsChrome(),
+    isInstallAvailable: () => isInstallAvailable(),
+    isInstalled: () => isInstalled(),
+    isStandalone: () => isStandaloneMode(),
+    setStatusListener: (listener) => {
+      statusListener = listener;
+      notifyStatusChanged();
+    },
+    clearStatusListener: () => {
+      statusListener = null;
+    },
+    promptInstall: async () => {
+      if (!isInstallAvailable()) {
+        return 'unavailable';
+      }
+
+      const promptEvent = deferredInstallPrompt;
+      deferredInstallPrompt = null;
+      await promptEvent.prompt();
+      const choice = await promptEvent.userChoice;
+
+      if (choice && choice.outcome === 'accepted') {
+        try {
+          window.localStorage.setItem(installedStorageKey, 'true');
+        } catch (_) {}
+      }
+
+      notifyStatusChanged();
+      return choice?.outcome || 'dismissed';
+    },
+    openApp: () => {
+      if (!isInstalled()) {
+        return false;
+      }
+
+      const launchUrl = new URL(window.location.href);
+      launchUrl.searchParams.set('source', 'pwa-open');
+      window.open(launchUrl.toString(), '_blank');
+      return true;
+    },
+  };
+})();
+
 // Web development suggestions for HTML, CSS, and JavaScript
 const htmlSuggestions = [
   // HTML Tags

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,13 +1,22 @@
 {
-    "name": "python_web_ide",
-    "short_name": "python_web_ide",
+    "name": "HTML Web IDE",
+    "short_name": "HTML IDE",
+    "id": "./",
     "start_url": ".",
+    "scope": ".",
     "display": "standalone",
-    "background_color": "#0175C2",
-    "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "background_color": "#1E1E1E",
+    "theme_color": "#1E1E1E",
+    "description": "A Flutter-powered HTML, CSS, and JavaScript web IDE.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
+    "related_applications": [
+        {
+            "platform": "webapp",
+            "url": "manifest.json",
+            "id": "./"
+        }
+    ],
     "icons": [
         {
             "src": "icons/Icon-192.png",


### PR DESCRIPTION
## Summary
- add a toolbar action that shows `Install app` when the PWA install prompt is available on Windows Chrome
- switch the action to `Open in app` when the app is already installed or running in standalone mode
- add JS interop bindings for PWA support, install availability, install prompting, and app launch
- wire the web app manifest into `index.html` and update manifest metadata for install detection and desktop-style PWA behavior

## Testing
- Not run (not requested)